### PR TITLE
feat(merge_request_hook): allow to disable email_username_not_match check

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -36,6 +36,7 @@ DEFAULT_BOT_GITLAB_MERGE_REQUEST_MILESTONE_REQUIRED_VALUE = "false"
 DEFAULT_BOT_GITLAB_MERGE_REQUEST_ISSUE_REQUIRED_VALUE = "false"
 DEFAULT_BOT_GIT_COMMIT_SUBJECT_REGEX_ENABLED = "true"
 DEFAULT_BOT_GITLAB_MERGE_REQUEST_SUMMARY_ENABLED_VALUE = "true"
+DEFAULT_BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED = "false"
 
 # openai api
 openai_api_base = os.getenv("OPENAI_API_BASE")
@@ -109,4 +110,13 @@ bot_gitlab_merge_request_summary_enabled = (
 # gitlab merge request summary
 bot_gitlab_merge_request_summary_language = os.getenv(
     "BOT_GITLAB_MERGE_REQUEST_SUMMARY_LANGUAGE", "English"
+)
+
+# gitlab merge request email username not match check
+bot_gitlab_merge_request_email_username_not_match_enabled = (
+    os.getenv(
+        "BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED",
+        DEFAULT_BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED,
+    ).lower()
+    == "true"
 )

--- a/src/merge_request_hook.py
+++ b/src/merge_request_hook.py
@@ -24,6 +24,7 @@ from src.config import (
     bot_gitlab_merge_request_milestone_required,
     bot_gitlab_merge_request_summary_enabled,
     bot_gitlab_username,
+    bot_gitlab_merge_request_email_username_not_match_enabled
 )
 from src.i18n import _
 from src.llm import AI, ai_diffs_summary
@@ -77,7 +78,7 @@ def check_email(commit_author_name, commit_author_email):
                     gitlab_email_domain=bot_git_email_domain,
                 )
             )
-        if username != commit_author_name:
+        if bot_gitlab_merge_request_email_username_not_match_enabled and username != commit_author_name:
             raise Exception(
                 _("email_username_not_match").format(
                     commit_author_name=commit_author_name,


### PR DESCRIPTION
This change introduces a new configuration option that allows disabling the email username mismatch check when processing merge requests.  Previously, the bot would automatically fail a merge request if the email address associated with a commit didn't match the GitLab username. This could be problematic in cases where users have different email addresses for their GitLab account and for commit authorship.

The code modification adds a new environment variable, `BOT_GITLAB_MERGE_REQUEST_EMAIL_USERNAME_NOT_MATCH_ENABLED`, which defaults to "false". This allows us to explicitly enable or disable the email username check as needed. If the variable is set to "true", the check is enabled. Otherwise, it is disabled.

The `check_email` function in `merge_request_hook.py` is updated to respect this new configuration setting.