### PR TITLE
chore: set `aiohttp` package as a separated dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-gidgetlab[aiohttp]>=1.1.0
+gidgetlab>=1.1.0
+aiohttp==3.11.7
 langchain_core==0.2.0
 langchain-openai==0.1.7
 langchain-google-genai==1.0.4 # This package contains the LangChain integrations for the Gemini API.


### PR DESCRIPTION
Set `aiohttp` as a standalone dependency, decoupling it from the `gidgetlab` dependency, and pin it to version `3.11.7` to mitigate known vulnerabilities.